### PR TITLE
check for definition of current user

### DIFF
--- a/lib/metova/logger/controller_patch.rb
+++ b/lib/metova/logger/controller_patch.rb
@@ -5,7 +5,7 @@ module Metova
       def append_info_to_payload(payload)
         super
         payload[:ip] = request.remote_ip
-        if current_user
+        if defined?(current_user) && current_user
           payload[:user] = [
             (current_user.try(:email) || 'NOEMAIL'),
             current_user.id


### PR DESCRIPTION
blows up if current_user is not defined (this would never happen if using the template, but does make the gem less general). 
